### PR TITLE
Purged the OTP 25 compilation warnings

### DIFF
--- a/src/ecron_spec.erl
+++ b/src/ecron_spec.erl
@@ -331,9 +331,9 @@ take(Key, Spec) ->
 parse_crontab([], Acc) ->
     {ok, Acc};
 parse_crontab([{Name, Spec, {_M, _F, _A} = MFA} | Jobs], Acc) ->
-    parse_crontab([{Name, Spec, {_M, _F, _A} = MFA, unlimited, unlimited, []} | Jobs], Acc);
+    parse_crontab([{Name, Spec, MFA, unlimited, unlimited, []} | Jobs], Acc);
 parse_crontab([{Name, Spec, {_M, _F, _A} = MFA, Start, End} | Jobs], Acc) ->
-    parse_crontab([{Name, Spec, {_M, _F, _A} = MFA, Start, End, []} | Jobs], Acc);
+    parse_crontab([{Name, Spec, MFA, Start, End, []} | Jobs], Acc);
 parse_crontab([{Name, Spec, {_M, _F, _A} = MFA, Start, End, Opts} | Jobs], Acc) ->
     case parse_job(Name, Spec, MFA, Start, End, Opts) of
         {ok, Job} ->


### PR DESCRIPTION
I purged the warnings that are appearing during compilation with OTP 25:

```
$ rebar3 --version 
rebar 3.19.0 on Erlang/OTP 25 Erts 13.1.1
```

```
===> Compiling ecron
_build/default/lib/ecron/src/ecron_spec.erl:334:34: Warning: variable '_M' is already bound. If you mean to ignore this value, use '_' or a different underscore-prefixed name
_build/default/lib/ecron/src/ecron_spec.erl:334:38: Warning: variable '_F' is already bound. If you mean to ignore this value, use '_' or a different underscore-prefixed name
_build/default/lib/ecron/src/ecron_spec.erl:334:42: Warning: variable '_A' is already bound. If you mean to ignore this value, use '_' or a different underscore-prefixed name
_build/default/lib/ecron/src/ecron_spec.erl:336:34: Warning: variable '_M' is already bound. If you mean to ignore this value, use '_' or a different underscore-prefixed name
_build/default/lib/ecron/src/ecron_spec.erl:336:38: Warning: variable '_F' is already bound. If you mean to ignore this value, use '_' or a different underscore-prefixed name
_build/default/lib/ecron/src/ecron_spec.erl:336:42: Warning: variable '_A' is already bound. If you mean to ignore this value, use '_' or a different underscore-prefixed name
```
